### PR TITLE
fix: mismatch main file name and missing requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ uv run mypy src/
 ```
 claude-code-proxy/
 ├── src/
-│   ├── claude_to_openai_server.py  # Main server
+│   ├── main.py  # Main server
 │   ├── test_claude_to_openai.py    # Tests
 │   └── [other modules...]
 ├── start_proxy.py                  # Startup script

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ Repository = "https://github.com/holegots/claude-code-proxy.git"
 Issues = "https://github.com/holegots/claude-code-proxy/issues"
 
 [project.scripts]
-claude-code-proxy = "src.claude_to_openai_server:main"
+claude-code-proxy = "src.main:main"
 
 [tool.uv]
 dev-dependencies = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+fastapi[standard]>=0.115.11
+uvicorn>=0.34.0
+pydantic>=2.0.0
+python-dotenv>=1.0.0
+openai>=1.54.0
+# Dev dependencies
+pytest>=7.0.0
+pytest-asyncio>=0.21.0
+httpx>=0.25.0
+black>=23.0.0
+isort>=5.12.0
+mypy>=1.0.0


### PR DESCRIPTION
- correct main file name so that `uv run claude-code-proxy` could works!
- add missing `requirements.txt` which is mentioned in `README.md` & `QUICKSTART.md`