### PR TITLE
Update .env.example for Azure OpenAI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,10 +28,10 @@ MAX_RETRIES="2"
 
 # For Azure OpenAI (recommended if OpenAI is not available in your region):
 # OPENAI_API_KEY="your-azure-api-key"
-# OPENAI_BASE_URL="https://your-resource-name.openai.azure.com/openai/deployments/your-deployment-name"
+# OPENAI_BASE_URL="https://your-resource-name.openai.azure.com/"
 # AZURE_API_VERSION="2024-03-01-preview"
-# BIG_MODEL="gpt-4"
-# SMALL_MODEL="gpt-35-turbo"
+# BIG_MODEL="gpt-4.1"  # these are your deployment names, which are not necessarily 1:1 equivalent with the model names
+# SMALL_MODEL="gpt-4.1-mini"
 
 # For local models (like Ollama):
 # OPENAI_API_KEY="dummy-key"  # Required but can be any value for local models


### PR DESCRIPTION
The Azure OPENAI_BASE_URL must not contain the deployment, as the URL is otherwise wrongly constructed.