### PR TITLE
Add client API key validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,10 @@
 # Required: Your OpenAI API key
 OPENAI_API_KEY="sk-your-openai-api-key-here"
 
+# Optional: Expected Anthropic API key for client validation
+# If set, clients must provide this exact API key to access the proxy
+ANTHROPIC_API_KEY="your-expected-anthropic-api-key"
+
 # Optional: OpenAI API base URL (default: https://api.openai.com/v1)
 # You can change this to use other providers like Azure OpenAI, local models, etc.
 OPENAI_BASE_URL="https://api.openai.com/v1"

--- a/README.md
+++ b/README.md
@@ -46,7 +46,11 @@ uv run claude-code-proxy
 ### 4. Use with Claude Code
 
 ```bash
-ANTHROPIC_BASE_URL=http://localhost:8082 ANTHROPIC_AUTH_TOKEN="some-api-key" claude
+# If ANTHROPIC_API_KEY is not set in the proxy:
+ANTHROPIC_BASE_URL=http://localhost:8082 ANTHROPIC_API_KEY="any-value" claude
+
+# If ANTHROPIC_API_KEY is set in the proxy:
+ANTHROPIC_BASE_URL=http://localhost:8082 ANTHROPIC_API_KEY="exact-matching-key" claude
 ```
 
 ## Configuration
@@ -56,6 +60,12 @@ ANTHROPIC_BASE_URL=http://localhost:8082 ANTHROPIC_AUTH_TOKEN="some-api-key" cla
 **Required:**
 
 - `OPENAI_API_KEY` - Your API key for the target provider
+
+**Security:**
+
+- `ANTHROPIC_API_KEY` - Expected Anthropic API key for client validation
+  - If set, clients must provide this exact API key to access the proxy
+  - If not set, any API key will be accepted
 
 **Model Configuration:**
 

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -8,6 +8,11 @@ class Config:
         if not self.openai_api_key:
             raise ValueError("OPENAI_API_KEY not found in environment variables")
         
+        # Add Anthropic API key for client validation
+        self.anthropic_api_key = os.environ.get("ANTHROPIC_API_KEY")
+        if not self.anthropic_api_key:
+            print("Warning: ANTHROPIC_API_KEY not set. Client API key validation will be disabled.")
+        
         self.openai_base_url = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
         self.azure_api_version = os.environ.get("AZURE_API_VERSION")  # For Azure OpenAI
         self.host = os.environ.get("HOST", "0.0.0.0")
@@ -32,6 +37,15 @@ class Config:
         if not self.openai_api_key.startswith('sk-'):
             return False
         return True
+        
+    def validate_client_api_key(self, client_api_key):
+        """Validate client's Anthropic API key"""
+        # If no ANTHROPIC_API_KEY is set in the environment, skip validation
+        if not self.anthropic_api_key:
+            return True
+            
+        # Check if the client's API key matches the expected value
+        return client_api_key == self.anthropic_api_key
 
 try:
     config = Config()

--- a/src/main.py
+++ b/src/main.py
@@ -19,6 +19,8 @@ def main():
         print("  OPENAI_API_KEY - Your OpenAI API key")
         print("")
         print("Optional environment variables:")
+        print("  ANTHROPIC_API_KEY - Expected Anthropic API key for client validation")
+        print("                      If set, clients must provide this exact API key")
         print(
             f"  OPENAI_BASE_URL - OpenAI API base URL (default: https://api.openai.com/v1)"
         )
@@ -45,6 +47,7 @@ def main():
     print(f"   Max Tokens Limit: {config.max_tokens_limit}")
     print(f"   Request Timeout: {config.request_timeout}s")
     print(f"   Server: {config.host}:{config.port}")
+    print(f"   Client API Key Validation: {'Enabled' if config.anthropic_api_key else 'Disabled'}")
     print("")
 
     # Parse log level - extract just the first word to handle comments


### PR DESCRIPTION
## Description
This PR adds client API key validation to the Claude Code Proxy. Previously, when a client set `ANTHROPIC_BASE_URL` to point to the proxy, they could use any value for `ANTHROPIC_API_KEY`. This change adds validation to ensure that the client API key matches a predefined value set in the proxy environment.

## Changes
- Added `ANTHROPIC_API_KEY` environment variable to the Config class
- Added a `validate_client_api_key` method to validate client API keys
- Created a FastAPI dependency function to extract and validate API keys from request headers
- Added API key validation to the `/v1/messages` and `/v1/messages/count_tokens` endpoints
- Updated documentation, help text, and startup messages to include information about the new feature
- Updated health check and root endpoints to show API key validation status

## How to Use
1. Set the `ANTHROPIC_API_KEY` environment variable in the proxy to the expected API key value
2. Clients must provide this exact API key when making requests to the proxy
3. If `ANTHROPIC_API_KEY` is not set in the proxy, any API key will be accepted (previous behavior)

## Testing
Tested by running the proxy with `ANTHROPIC_API_KEY` set and verifying that the startup message shows "Client API Key Validation: Enabled"