### PR TITLE
feat: add support for additional model prefixes in mapping

### DIFF
--- a/src/core/model_manager.py
+++ b/src/core/model_manager.py
@@ -9,6 +9,11 @@ class ModelManager:
         # If it's already an OpenAI model, return as-is
         if claude_model.startswith("gpt-") or claude_model.startswith("o1-"):
             return claude_model
+
+        # If it's other supported models (ARK/Doubao/DeepSeek), return as-is
+        if (claude_model.startswith("ep-") or claude_model.startswith("doubao-") or 
+            claude_model.startswith("deepseek-")):
+            return claude_model
         
         # Map based on model naming patterns
         model_lower = claude_model.lower()


### PR DESCRIPTION
This pull request updates the `map_claude_model_to_openai` method in `src/core/model_manager.py` to handle additional model naming patterns. The change ensures that models with prefixes `ep-`, `doubao-`, and `deepseek-` are returned as-is, improving compatibility with these supported models.

* [`src/core/model_manager.py`](diffhunk://#diff-71481e7e802075259a68511eeef43b4cc516f6d0207a57b14bc8c6b81920cfc8R13-R17): Added checks for model prefixes `ep-`, `doubao-`, and `deepseek-` in the `map_claude_model_to_openai` method to return them directly without further mapping.