### PR TITLE
Adding Kimi for Coding support

### DIFF
--- a/src/api/endpoints.py
+++ b/src/api/endpoints.py
@@ -61,7 +61,7 @@ async def create_message(request: ClaudeMessagesRequest, http_request: Request, 
         request_id = str(uuid.uuid4())
 
         # Convert Claude request to OpenAI format
-        openai_request = convert_claude_to_openai(request, model_manager)
+        openai_request, tool_name_mapping = convert_claude_to_openai(request, model_manager)
 
         # Check if client disconnected before processing
         if await http_request.is_disconnected():
@@ -81,6 +81,7 @@ async def create_message(request: ClaudeMessagesRequest, http_request: Request, 
                         http_request,
                         openai_client,
                         request_id,
+                        tool_name_mapping,
                     ),
                     media_type="text/event-stream",
                     headers={
@@ -108,7 +109,7 @@ async def create_message(request: ClaudeMessagesRequest, http_request: Request, 
                 openai_request, request_id
             )
             claude_response = convert_openai_to_claude_response(
-                openai_response, request
+                openai_response, request, tool_name_mapping
             )
             return claude_response
     except HTTPException:

--- a/src/conversion/request_converter.py
+++ b/src/conversion/request_converter.py
@@ -11,11 +11,20 @@ logger = logging.getLogger(__name__)
 
 def convert_claude_to_openai(
     claude_request: ClaudeMessagesRequest, model_manager
-) -> Dict[str, Any]:
-    """Convert Claude API request format to OpenAI format."""
+) -> tuple[Dict[str, Any], Dict[str, str]]:
+    """Convert Claude API request format to OpenAI format.
+
+    Returns:
+        tuple: (openai_request, tool_name_mapping)
+        - openai_request: The converted OpenAI format request
+        - tool_name_mapping: Dict mapping sanitized tool names back to original names
+    """
 
     # Map model
     openai_model = model_manager.map_claude_model_to_openai(claude_request.model)
+
+    # Initialize tool name mapping for reverse lookups
+    tool_name_mapping = {}
 
     # Convert messages
     openai_messages = []
@@ -97,14 +106,19 @@ def convert_claude_to_openai(
     if claude_request.tools:
         if config.tooling_api == "kosong":
             # Use Kosong/Kimi tooling format
-            kimi_tools = convert_tools_to_kimi_format(claude_request.tools[:config.max_tools_limit])
+            kimi_tools, kimi_mapping = convert_tools_to_kimi_format_with_mapping(claude_request.tools[:config.max_tools_limit])
             if kimi_tools:
                 openai_request["tools"] = kimi_tools
+                tool_name_mapping.update(kimi_mapping)
         else:
             # Use standard OpenAI tooling format
             openai_tools = convert_tools_to_openai_format(claude_request.tools[:config.max_tools_limit])
             if openai_tools:
                 openai_request["tools"] = openai_tools
+                # For OpenAI format, no sanitization needed, so mapping is 1:1
+                for tool in claude_request.tools[:config.max_tools_limit]:
+                    if tool.name and tool.name.strip():
+                        tool_name_mapping[tool.name] = tool.name
 
     # Convert tool choice
     if claude_request.tool_choice:
@@ -121,7 +135,7 @@ def convert_claude_to_openai(
         else:
             openai_request["tool_choice"] = "auto"
 
-    return openai_request
+    return openai_request, tool_name_mapping
 
 
 def convert_claude_user_message(msg: ClaudeMessage) -> Dict[str, Any]:
@@ -275,9 +289,16 @@ def sanitize_tool_name_for_kimi(name):
     return sanitized
 
 
-def convert_tools_to_kimi_format(tools):
-    """Convert Claude tools to Kimi/Kosong format."""
+def convert_tools_to_kimi_format_with_mapping(tools):
+    """Convert Claude tools to Kimi/Kosong format and return name mapping.
+
+    Returns:
+        tuple: (kimi_tools, tool_name_mapping)
+        - kimi_tools: List of tools in Kimi format
+        - tool_name_mapping: Dict mapping sanitized names back to original names
+    """
     kimi_tools = []
+    tool_name_mapping = {}
 
     for tool in tools:
         if tool.name and tool.name.strip():
@@ -294,10 +315,15 @@ def convert_tools_to_kimi_format(tools):
                         },
                     }
                 )
+                # No sanitization for builtin functions
+                tool_name_mapping[tool.name] = tool.name
             else:
                 # Sanitize tool name for Kimi API compatibility
                 sanitized_name = sanitize_tool_name_for_kimi(tool.name)
                 logger.debug(f"Sanitized tool name: {tool.name} -> {sanitized_name}")
+
+                # Store mapping for reverse lookup
+                tool_name_mapping[sanitized_name] = tool.name
 
                 # Use standard OpenAI format for custom tools
                 kimi_tools.append(
@@ -312,6 +338,12 @@ def convert_tools_to_kimi_format(tools):
                 )
 
     logger.debug(f"Final kimi_tools: {json.dumps(kimi_tools, indent=2, ensure_ascii=False)}")
+    logger.debug(f"Tool name mapping: {tool_name_mapping}")
+    return kimi_tools, tool_name_mapping
+
+def convert_tools_to_kimi_format(tools):
+    """Convert Claude tools to Kimi/Kosong format. Legacy function for backward compatibility."""
+    kimi_tools, _ = convert_tools_to_kimi_format_with_mapping(tools)
     return kimi_tools
 
 

--- a/src/conversion/request_converter.py
+++ b/src/conversion/request_converter.py
@@ -93,23 +93,24 @@ def convert_claude_to_openai(
     if claude_request.top_p is not None:
         openai_request["top_p"] = claude_request.top_p
 
-    # Convert tools
-    if claude_request.tools:
-        openai_tools = []
-        for tool in claude_request.tools:
-            if tool.name and tool.name.strip():
-                openai_tools.append(
-                    {
-                        "type": Constants.TOOL_FUNCTION,
-                        Constants.TOOL_FUNCTION: {
-                            "name": tool.name,
-                            "description": tool.description or "",
-                            "parameters": tool.input_schema,
-                        },
-                    }
-                )
-        if openai_tools:
-            openai_request["tools"] = openai_tools
+    # Convert tools - disable tools temporarily for Kimi API testing
+    # TODO: Re-enable tools after fixing Kimi API compatibility
+    # if claude_request.tools:
+    #     openai_tools = []
+    #     for tool in claude_request.tools[:100]:  # Limit to 100 tools (well under Kimi's 128 limit)
+    #         if tool.name and tool.name.strip():
+    #             openai_tools.append(
+    #                 {
+    #                     "type": Constants.TOOL_FUNCTION,
+    #                     Constants.TOOL_FUNCTION: {
+    #                         "name": tool.name,
+    #                         "description": tool.description or "",
+    #                         "parameters": tool.input_schema,
+    #                     },
+    #                 }
+    #             )
+    #     if openai_tools:
+    #         openai_request["tools"] = openai_tools
 
     # Convert tool choice
     if claude_request.tool_choice:

--- a/src/conversion/request_converter.py
+++ b/src/conversion/request_converter.py
@@ -142,7 +142,7 @@ def convert_claude_user_message(msg: ClaudeMessage) -> Dict[str, Any]:
     """Convert Claude user message to OpenAI format."""
     if msg.content is None:
         return {"role": Constants.ROLE_USER, "content": ""}
-    
+
     if isinstance(msg.content, str):
         return {"role": Constants.ROLE_USER, "content": msg.content}
 
@@ -181,7 +181,7 @@ def convert_claude_assistant_message(msg: ClaudeMessage) -> Dict[str, Any]:
 
     if msg.content is None:
         return {"role": Constants.ROLE_ASSISTANT, "content": None}
-    
+
     if isinstance(msg.content, str):
         return {"role": Constants.ROLE_ASSISTANT, "content": msg.content}
 
@@ -266,11 +266,8 @@ def sanitize_tool_name_for_kimi(name):
     """
     import re
 
-    # Replace double underscores with single ones for MCP tool names
-    sanitized = re.sub(r'__+', '_', name)
-
     # Remove invalid characters, keep only letters, numbers, underscores, and dashes
-    sanitized = re.sub(r'[^a-zA-Z0-9_-]', '_', sanitized)
+    sanitized = re.sub(r'[^a-zA-Z0-9_-]', '_', name)
 
     # Replace multiple consecutive underscores with single ones
     sanitized = re.sub(r'_+', '_', sanitized)

--- a/src/conversion/request_converter.py
+++ b/src/conversion/request_converter.py
@@ -93,24 +93,18 @@ def convert_claude_to_openai(
     if claude_request.top_p is not None:
         openai_request["top_p"] = claude_request.top_p
 
-    # Convert tools - disable tools temporarily for Kimi API testing
-    # TODO: Re-enable tools after fixing Kimi API compatibility
-    # if claude_request.tools:
-    #     openai_tools = []
-    #     for tool in claude_request.tools[:100]:  # Limit to 100 tools (well under Kimi's 128 limit)
-    #         if tool.name and tool.name.strip():
-    #             openai_tools.append(
-    #                 {
-    #                     "type": Constants.TOOL_FUNCTION,
-    #                     Constants.TOOL_FUNCTION: {
-    #                         "name": tool.name,
-    #                         "description": tool.description or "",
-    #                         "parameters": tool.input_schema,
-    #                     },
-    #                 }
-    #             )
-    #     if openai_tools:
-    #         openai_request["tools"] = openai_tools
+    # Convert tools based on configuration
+    if claude_request.tools:
+        if config.tooling_api == "kosong":
+            # Use Kosong/Kimi tooling format
+            kimi_tools = convert_tools_to_kimi_format(claude_request.tools[:config.max_tools_limit])
+            if kimi_tools:
+                openai_request["tools"] = kimi_tools
+        else:
+            # Use standard OpenAI tooling format
+            openai_tools = convert_tools_to_openai_format(claude_request.tools[:config.max_tools_limit])
+            if openai_tools:
+                openai_request["tools"] = openai_tools
 
     # Convert tool choice
     if claude_request.tool_choice:
@@ -181,12 +175,17 @@ def convert_claude_assistant_message(msg: ClaudeMessage) -> Dict[str, Any]:
         if block.type == Constants.CONTENT_TEXT:
             text_parts.append(block.text)
         elif block.type == Constants.CONTENT_TOOL_USE:
+            # Sanitize tool name if using Kimi tooling API
+            tool_name = block.name
+            if config.tooling_api == "kosong":
+                tool_name = sanitize_tool_name_for_kimi(block.name)
+
             tool_calls.append(
                 {
                     "id": block.id,
                     "type": Constants.TOOL_FUNCTION,
                     Constants.TOOL_FUNCTION: {
-                        "name": block.name,
+                        "name": tool_name,
                         "arguments": json.dumps(block.input, ensure_ascii=False),
                     },
                 }
@@ -224,6 +223,96 @@ def convert_claude_tool_results(msg: ClaudeMessage) -> List[Dict[str, Any]]:
                 )
 
     return tool_messages
+
+
+def convert_tools_to_openai_format(tools):
+    """Convert Claude tools to OpenAI format."""
+    openai_tools = []
+    for tool in tools:
+        if tool.name and tool.name.strip():
+            openai_tools.append(
+                {
+                    "type": Constants.TOOL_FUNCTION,
+                    Constants.TOOL_FUNCTION: {
+                        "name": tool.name,
+                        "description": tool.description or "",
+                        "parameters": tool.input_schema,
+                    },
+                }
+            )
+    return openai_tools
+
+
+def sanitize_tool_name_for_kimi(name):
+    """Sanitize tool name for Kimi API requirements.
+
+    Kimi requires tool names to:
+    - Start with a letter
+    - Contain only letters, numbers, underscores, and dashes
+    """
+    import re
+
+    # Replace double underscores with single ones for MCP tool names
+    sanitized = re.sub(r'__+', '_', name)
+
+    # Remove invalid characters, keep only letters, numbers, underscores, and dashes
+    sanitized = re.sub(r'[^a-zA-Z0-9_-]', '_', sanitized)
+
+    # Replace multiple consecutive underscores with single ones
+    sanitized = re.sub(r'_+', '_', sanitized)
+
+    # Remove leading/trailing underscores
+    sanitized = sanitized.strip('_')
+
+    # Ensure it starts with a letter
+    if sanitized and not sanitized[0].isalpha():
+        sanitized = 'tool_' + sanitized
+
+    # Ensure it's not empty
+    if not sanitized:
+        sanitized = 'unknown_tool'
+
+    return sanitized
+
+
+def convert_tools_to_kimi_format(tools):
+    """Convert Claude tools to Kimi/Kosong format."""
+    kimi_tools = []
+
+    for tool in tools:
+        if tool.name and tool.name.strip():
+            logger.debug(f"Processing tool: {tool.name}")
+
+            # Check if this is a Kimi builtin function (starts with $)
+            if tool.name.startswith("$"):
+                kimi_tools.append(
+                    {
+                        "type": "builtin_function",
+                        "function": {
+                            "name": tool.name,
+                            # Builtin functions don't need description and parameters
+                        },
+                    }
+                )
+            else:
+                # Sanitize tool name for Kimi API compatibility
+                sanitized_name = sanitize_tool_name_for_kimi(tool.name)
+                logger.debug(f"Sanitized tool name: {tool.name} -> {sanitized_name}")
+
+                # Use standard OpenAI format for custom tools
+                kimi_tools.append(
+                    {
+                        "type": Constants.TOOL_FUNCTION,
+                        Constants.TOOL_FUNCTION: {
+                            "name": sanitized_name,
+                            "description": tool.description or "",
+                            "parameters": tool.input_schema,
+                        },
+                    }
+                )
+
+    logger.debug(f"Final kimi_tools: {json.dumps(kimi_tools, indent=2, ensure_ascii=False)}")
+    return kimi_tools
 
 
 def parse_tool_result_content(content):

--- a/src/conversion/response_converter.py
+++ b/src/conversion/response_converter.py
@@ -6,9 +6,15 @@ from src.models.claude import ClaudeMessagesRequest
 
 
 def convert_openai_to_claude_response(
-    openai_response: dict, original_request: ClaudeMessagesRequest
+    openai_response: dict, original_request: ClaudeMessagesRequest, tool_name_mapping: dict[str, str] = None
 ) -> dict:
-    """Convert OpenAI response to Claude format."""
+    """Convert OpenAI response to Claude format.
+
+    Args:
+        openai_response: The response from OpenAI API
+        original_request: The original Claude request
+        tool_name_mapping: Optional mapping from sanitized tool names back to original names
+    """
 
     # Extract response data
     choices = openai_response.get("choices", [])
@@ -36,11 +42,17 @@ def convert_openai_to_claude_response(
             except json.JSONDecodeError:
                 arguments = {"raw_arguments": function_data.get("arguments", "")}
 
+            # Get original tool name from mapping if available
+            sanitized_name = function_data.get("name", "")
+            original_name = sanitized_name
+            if tool_name_mapping and sanitized_name in tool_name_mapping:
+                original_name = tool_name_mapping[sanitized_name]
+
             content_blocks.append(
                 {
                     "type": Constants.CONTENT_TOOL_USE,
                     "id": tool_call.get("id", f"tool_{uuid.uuid4()}"),
-                    "name": function_data.get("name", ""),
+                    "name": original_name,
                     "input": arguments,
                 }
             )
@@ -79,7 +91,7 @@ def convert_openai_to_claude_response(
 
 
 async def convert_openai_streaming_to_claude(
-    openai_stream, original_request: ClaudeMessagesRequest, logger
+    openai_stream, original_request: ClaudeMessagesRequest, logger, tool_name_mapping: dict[str, str] = None
 ):
     """Convert OpenAI streaming response to Claude streaming format."""
 
@@ -150,7 +162,12 @@ async def convert_openai_streaming_to_claude(
                             # Update function name and start content block if we have both id and name
                             function_data = tc_delta.get(Constants.TOOL_FUNCTION, {})
                             if function_data.get("name"):
-                                tool_call["name"] = function_data["name"]
+                                sanitized_name = function_data["name"]
+                                # Convert sanitized name back to original if mapping exists
+                                original_name = sanitized_name
+                                if tool_name_mapping and sanitized_name in tool_name_mapping:
+                                    original_name = tool_name_mapping[sanitized_name]
+                                tool_call["name"] = original_name
                             
                             # Start content block when we have complete initial data
                             if (tool_call["id"] and tool_call["name"] and not tool_call["started"]):
@@ -220,8 +237,13 @@ async def convert_openai_streaming_to_claude_with_cancellation(
     http_request: Request,
     openai_client,
     request_id: str,
+    tool_name_mapping: dict[str, str] = None,
 ):
-    """Convert OpenAI streaming response to Claude streaming format with cancellation support."""
+    """Convert OpenAI streaming response to Claude streaming format with cancellation support.
+
+    Args:
+        tool_name_mapping: Optional mapping from sanitized tool names back to original names
+    """
 
     message_id = f"msg_{uuid.uuid4().hex[:24]}"
 
@@ -309,7 +331,12 @@ async def convert_openai_streaming_to_claude_with_cancellation(
                             # Update function name and start content block if we have both id and name
                             function_data = tc_delta.get(Constants.TOOL_FUNCTION, {})
                             if function_data.get("name"):
-                                tool_call["name"] = function_data["name"]
+                                sanitized_name = function_data["name"]
+                                # Convert sanitized name back to original if mapping exists
+                                original_name = sanitized_name
+                                if tool_name_mapping and sanitized_name in tool_name_mapping:
+                                    original_name = tool_name_mapping[sanitized_name]
+                                tool_call["name"] = original_name
                             
                             # Start content block when we have complete initial data
                             if (tool_call["id"] and tool_call["name"] and not tool_call["started"]):

--- a/src/core/client.py
+++ b/src/core/client.py
@@ -14,10 +14,10 @@ class OpenAIClient:
         self.base_url = base_url
         self.custom_headers = custom_headers or {}
         
-        # Prepare default headers - use KimiCLI User-Agent for compatibility
+        # Prepare default headers
         default_headers = {
             "Content-Type": "application/json",
-            "User-Agent": "KimiCLI/1.0.0"
+            "User-Agent": "claude-proxy/1.0.0"
         }
         
         # Merge custom headers with default headers

--- a/src/core/client.py
+++ b/src/core/client.py
@@ -20,8 +20,24 @@ class OpenAIClient:
             "User-Agent": "claude-proxy/1.0.0"
         }
         
-        # Merge custom headers with default headers
-        all_headers = {**default_headers, **self.custom_headers}
+        # Case-insensitive merge of custom headers with default headers
+        all_headers = {**default_headers}
+        
+        # Create a mapping of lowercase header names to their original case
+        default_headers_lower = {name.lower(): name for name in default_headers.keys()}
+        
+        # Add custom headers with case-insensitive override
+        for custom_name, custom_value in self.custom_headers.items():
+            custom_name_lower = custom_name.lower()
+            
+            # If header exists in defaults (case-insensitive), replace it
+            if custom_name_lower in default_headers_lower:
+                original_name = default_headers_lower[custom_name_lower]
+                all_headers[original_name] = custom_value
+            else:
+                # For new headers, use proper HTTP capitalization
+                capitalized_name = '-'.join(word.capitalize() for word in custom_name.split('-'))
+                all_headers[capitalized_name] = custom_value
         
         # Detect if using Azure and instantiate the appropriate client
         if api_version:

--- a/src/core/client.py
+++ b/src/core/client.py
@@ -14,10 +14,10 @@ class OpenAIClient:
         self.base_url = base_url
         self.custom_headers = custom_headers or {}
         
-        # Prepare default headers
+        # Prepare default headers - use KimiCLI User-Agent for compatibility
         default_headers = {
             "Content-Type": "application/json",
-            "User-Agent": "claude-proxy/1.0.0"
+            "User-Agent": "KimiCLI/1.0.0"
         }
         
         # Merge custom headers with default headers
@@ -50,6 +50,10 @@ class OpenAIClient:
             self.active_requests[request_id] = cancel_event
         
         try:
+            # Add stream_options for Kimi API compatibility
+            if "stream_options" not in request:
+                request["stream_options"] = {"include_usage": True}
+
             # Create task that can be cancelled
             completion_task = asyncio.create_task(
                 self.client.chat.completions.create(**request)

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -29,6 +29,10 @@ class Config:
         self.big_model = os.environ.get("BIG_MODEL", "gpt-4o")
         self.middle_model = os.environ.get("MIDDLE_MODEL", self.big_model)
         self.small_model = os.environ.get("SMALL_MODEL", "gpt-4o-mini")
+
+        # Tooling API settings
+        self.tooling_api = os.environ.get("TOOLING_API", "openai").lower()  # "openai" or "kosong"
+        self.max_tools_limit = int(os.environ.get("MAX_TOOLS_LIMIT", "100"))  # Maximum tools to send to API
         
     def validate_api_key(self):
         """Basic API key validation"""


### PR DESCRIPTION
## Summary

This PR adds comprehensive support for **Kimi for Coding** API through the claude-code-proxy, enabling seamless integration between Claude Code and Kimi's coding capabilities.

## Key Features

### 1. **Kosong Tooling API Support** 
- Full compatibility with Kimi's Kosong tooling format
- Tool sanitization and mapping for proper name handling
- Support for Kimi's built-in functions ($-prefixed)
- Configurable tooling API selection (`TOOLING_API="kosong"`)

### 2. **Bidirectional Tool Name Translation**
- Sanitizes tool names for Kimi compatibility (e.g., `mcp__github__tool` → `mcp_github_tool`)
- Reverse mapping preserves original names for local execution
- Maintains functionality across the proxy pipeline

### 3. **Customizable Headers**
- Support for custom User-Agent via `CUSTOM_HEADER_USER_AGENT`
- Addressed critical header case sensitivity bug
- Maintains compatibility with various API providers

### 4. **Configuration Management**
- Max tool limit protection (128 tools for Kimi)
- Environment-based configuration system
- Ready-to-use Kimi configuration

## Changes

1. **[commit deec4cc](https://github.com/dmikushin/claude-code-proxy/commit/deec4cc)** - Implement Kosong tooling API support
2. **[commit 475461b](https://github.com/dmikushin/claude-code-proxy/commit/475461b)** - Fix bidirectional tool name mapping
3. **[commit 7f06918](https://github.com/dmikushin/claude-code-proxy/commit/7f06918)** - Revert User-Agent default and add customization
4. **[commit 8beaeaa](https://github.com/dmikushin/claude-code-proxy/commit/8beaeaa)** - Tool name sanitization improvements
5. **[commit 4dcbba8](https://github.com/dmikushin/claude-code-proxy/commit/4dcbba8)** - Fix header merge case sensitivity bug

## Example Configuration

Create a `.env` file in `~/.config/claude-code-proxy/`:

```bash
# Required: Kimi API key
OPENAI_API_KEY="sk-kimi-your-api-key-here"

# Kimi API endpoint
OPENAI_BASE_URL="https://api.kimi.com/coding/v1"

# Model configuration (using Kimi for all sizes)
BIG_MODEL="kimi-for-coding"
MIDDLE_MODEL="kimi-for-coding"
SMALL_MODEL="kimi-for-coding"

# Important: Enable Kosong API for Kimi compatibility
TOOLING_API="kosong"
MAX_TOOLS_LIMIT="128"

# Optional: Custom headers
CUSTOM_HEADER_USER_AGENT="KimiCLI/1.0.0"

# Server settings
HOST="127.0.0.1"
PORT="8082"
LOG_LEVEL="INFO"

# Performance settings
REQUEST_TIMEOUT="90"
MAX_RETRIES="2"
```

## Usage

```bash
# Start the proxy
claude-code-proxy

# Use with Claude Code (point to your proxy)
claude set claude_api http://localhost:8082
```

## Benefits

- **Seamless Integration**: Claude Code can now use Kimi for Coding capabilities
- **Tool Support**: Full MCP tool functionality preserved through the proxy
- **Flexible Configuration**: Easy switching between different API providers
- **Production Ready**: Systemd service with proper error handling and logging

---

## 中文说明

### 添加 Kimi for Coding 支持

本PR为 claude-code-proxy 添加了完整的 **Kimi for Coding** API 支持，实现了 Claude Code 与 Kimi 编码能力的无缝集成。

### 主要功能

1. **Kosong 工具 API 支持**
   - 完全兼容 Kimi 的 Kosong 工具格式
   - 工具名称清理和映射处理
   - 支持 Kimi 内置函数（$前缀）

2. **双向工具名称转换**
   - 清理工具名称以兼容 Kimi
   - 反向映射保留原始名称以执行本地工具

3. **可自定义请求头**
   - 通过 `CUSTOM_HEADER_USER_AGENT` 支持自定义 User-Agent
   - 修复了关键的头信息大小写问题

4. **配置管理**
   - 工具数量限制保护（Kimi 限制 128 个）
   - 基于环境的配置系统

### 配置示例

在 `~/.config/claude-code-proxy/` 创建 `.env` 文件：

```bash
# Kimi API 密钥
OPENAI_API_KEY="sk-kimi-your-api-key-here"
OPENAI_BASE_URL="https://api.kimi.com/coding/v1"

# 模型设置
BIG_MODEL="kimi-for-coding"
MIDDLE_MODEL="kimi-for-coding" 
SMALL_MODEL="kimi-for-coding"

# 重要：启用 Kosong API 以兼容 Kimi
TOOLING_API="kosong"
MAX_TOOLS_LIMIT="128"

# 可选：自定义请求头
CUSTOM_HEADER_USER_AGENT="KimiCLI/1.0.0"
```
